### PR TITLE
Laisser apparaitre le message d'erreur éventuel

### DIFF
--- a/prive/style_prive_plugin_bigup.html
+++ b/prive/style_prive_plugin_bigup.html
@@ -26,7 +26,10 @@
 #navigation .bigup_fichiers .previsualisation + .infos {
 	text-align:center;
 	flex-basis: 100%;
-	display:none;
+}
+#navigation .bigup_fichiers .previsualisation + .infos .name,
+#navigation .bigup_fichiers .previsualisation + .infos .size {
+	display: none;
 }
 #navigation .editer_fichier_upload {
 	min-height: 90px;


### PR DESCRIPTION
Ne pas masquer tout le bloc d'infos mais uniquement le nom et la taille.
Laisser apparaitre le message d'erreur éventuel (par exemple, si la taille de l'image dépasse le poids autorisé)