### PR TITLE
Ticket #4464 : ne pas faire dépasser la zone étendue en haut et en bas…

### DIFF
--- a/prive/style_prive_plugin_bigup.html
+++ b/prive/style_prive_plugin_bigup.html
@@ -112,8 +112,8 @@
 	content:'';
 	display: block;
 	position: absolute;
-	top:-10px;
-	bottom:-10px;
+	top: 0;
+	bottom: 0;
 	#GET{left}: -50vw;
 	#GET{right}: -10px;
 	background: #fff;


### PR DESCRIPTION
… car ça peut l'amener à recouvrir les blocs adjacents et empêche dans ce cas de cliquer sur les liens à l'intérieur (comme le fil d'ariane).